### PR TITLE
Removed protected default

### DIFF
--- a/src/Services/Nearby.php
+++ b/src/Services/Nearby.php
@@ -25,9 +25,7 @@ class Nearby extends Request
     protected $validParams = [
         'location', 'radius', 'type', 'rankby', 'keyword', 'language', 'minprice', 'maxprice', 'name', 'opennow', 'pagetoken'
     ];
-    protected $default = [
-        'radius' => 40233,
-    ];
+    
     /**
      * @var string
      */
@@ -50,6 +48,4 @@ class Nearby extends Request
         }
         parent::__construct($params);
     }
-
-
 }


### PR DESCRIPTION
It was causing the google api to return INVALID_REQUEST as it is setting both radius and rankby in the request. The default radius is already being set on line 47, so setting the default again via defaultParams is redundant.